### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,12 @@
       {
         "url": "https://a.klaviyo.com/api/.*",
         "methods": ["GET", "POST", "PATCH"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "api_key": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the API configuration in the `manifest.json` file to improve how the Klaviyo API key is managed. The main change is the introduction of a new `settingsInjection` section, which allows the API key to be automatically injected into the `Authorization` header for requests to the Klaviyo API.

API authentication improvements:

* Added a `settingsInjection` section to the Klaviyo API configuration, enabling automatic injection of the `api_key` into the `Authorization` header for all requests.